### PR TITLE
Fix for channel names containing a forward slash

### DIFF
--- a/lib/irclogger/viewer.rb
+++ b/lib/irclogger/viewer.rb
@@ -11,8 +11,7 @@ require 'irclogger/viewer_helpers'
 module IrcLogger
   class Viewer < Sinatra::Base
     set :views,         File.expand_path('../../../views', __FILE__)
-    set :public_folder, File.expand_path('../../../public', __FILE__)    
-    set :protection, :except => :path_traversal 
+    set :public_folder, File.expand_path('../../../public', __FILE__)
 
     configure :development do
       register Sinatra::Reloader

--- a/lib/irclogger/viewer.rb
+++ b/lib/irclogger/viewer.rb
@@ -11,7 +11,8 @@ require 'irclogger/viewer_helpers'
 module IrcLogger
   class Viewer < Sinatra::Base
     set :views,         File.expand_path('../../../views', __FILE__)
-    set :public_folder, File.expand_path('../../../public', __FILE__)
+    set :public_folder, File.expand_path('../../../public', __FILE__)    
+    set :protection, :except => :path_traversal 
 
     configure :development do
       register Sinatra::Reloader

--- a/lib/irclogger/viewer_helpers.rb
+++ b/lib/irclogger/viewer_helpers.rb
@@ -5,11 +5,11 @@ module IrcLogger
     include Rack::Utils
 
     def channel_escape(channel)
-      channel[1..-1].gsub(/\/+/, "%2F").gsub(/^#+/) { |m| '.' * m.length }
+      CGI.escape(channel[1..-1]).gsub(/^#+/) { |m| '.' * m.length }
     end
 
     def channel_unescape(channel)
-      "##{channel.gsub(/%2F+/, "/").gsub(/^\.+/) { |m| '#' * m.length }}"
+      "##{CGI.unescape(channel).gsub(/^\.+/) { |m| '#' * m.length }}"
     end
 
     def channel_url(channel, postfix=nil)

--- a/lib/irclogger/viewer_helpers.rb
+++ b/lib/irclogger/viewer_helpers.rb
@@ -9,7 +9,7 @@ module IrcLogger
     end
 
     def channel_unescape(channel)
-      "##{CGI.unescape(channel).gsub(/^\.+/) { |m| '#' * m.length }}"
+      "##{channel.gsub(/^\.+/) { |m| '#' * m.length }}"
     end
 
     def channel_url(channel, postfix=nil)

--- a/lib/irclogger/viewer_helpers.rb
+++ b/lib/irclogger/viewer_helpers.rb
@@ -5,27 +5,69 @@ module IrcLogger
     include Rack::Utils
     
     def escape_url(url)
-        url.gsub("%", "%25").
-            gsub("/", "%2F").
-            gsub("\\", "%5C").
-            gsub("?", "%3F").
-            gsub("#", "%23").
-            gsub("`", "%60").
-            gsub("<", "%3C").
-            gsub(">", "%3E").
-            gsub("|", "%7C").
-            gsub("{", "%7B").
-            gsub("}", "%7D").
-            gsub("^", "%5E")
+        url.gsub('~', '~~').
+            gsub('#', '~h~').
+            gsub('/', '~s~').
+            gsub('%', '~p~').
+            gsub('\\', '~r~').
+            gsub('?', '~q~').
+            gsub('`', '~a~').
+            gsub('<', '~l~').
+            gsub('>', '~g~').
+            gsub('|', '~b~').
+            gsub('{', '~o~').
+            gsub('}', '~c~').
+            gsub('^', '~x~').
+            gsub('"', '~d~')
+    end
+    
+    def unescape_url(url)
+        i = 0
+        text = ""
+        parts = url.split('~', -1)
+        while i < parts.length do
+            if i.even?
+                text += parts[i]
+            else
+                if parts[i].length == 0
+                    text += '~'
+                else
+                    if parts[i].length  == 1
+                        text += parts[i].gsub('h', '#').
+                                         gsub('s', '/').
+                                         gsub('p', '%').
+                                         gsub('r', '\\').
+                                         gsub('q', '?').
+                                         gsub('a', '`').
+                                         gsub('l', '<').
+                                         gsub('g', '>').
+                                         gsub('b', '|').
+                                         gsub('o', '{').
+                                         gsub('c', '}').
+                                         gsub('x', '^').
+                                         gsub('d', '"')
+                    else
+                        text += parts[i]
+                    end
+                end
+            end
+            i += 1
+        end
+        text
     end
         
 
     def channel_escape(channel)
-      escape_url(channel[1..-1]).gsub(/^#+/) { |m| '.' * m.length }
+      escape_url(channel[1..-1])
     end
 
     def channel_unescape(channel)
-      "##{channel.gsub(/^\.+/) { |m| '#' * m.length }}"
+      c = unescape_url(channel)
+      if Config.key?('legacy') and Config['legacy'].include? c
+        "##{c.gsub(/^\.+/) { |m| '#' * m.length }}"
+      else
+        "##{c}"
+      end
     end
 
     def channel_url(channel, postfix=nil)

--- a/lib/irclogger/viewer_helpers.rb
+++ b/lib/irclogger/viewer_helpers.rb
@@ -3,9 +3,25 @@ require 'zlib' # crc32
 module IrcLogger
   module ViewerHelpers
     include Rack::Utils
+    
+    def escape_url(url)
+        url.gsub("%", "%25").
+            gsub("/", "%2F").
+            gsub("\\", "%5C").
+            gsub("?", "%3F").
+            gsub("#", "%23").
+            gsub("`", "%60").
+            gsub("<", "%3C").
+            gsub(">", "%3E").
+            gsub("|", "%7C").
+            gsub("{", "%7B").
+            gsub("}", "%7D").
+            gsub("^", "%5E")
+    end
+        
 
     def channel_escape(channel)
-      CGI.escape(channel[1..-1]).gsub(/^#+/) { |m| '.' * m.length }
+      escape_url(channel[1..-1]).gsub(/^#+/) { |m| '.' * m.length }
     end
 
     def channel_unescape(channel)

--- a/lib/irclogger/viewer_helpers.rb
+++ b/lib/irclogger/viewer_helpers.rb
@@ -5,11 +5,11 @@ module IrcLogger
     include Rack::Utils
 
     def channel_escape(channel)
-      channel[1..-1].gsub(/^#+/) { |m| '.' * m.length }
+      channel[1..-1].gsub(/\/+/, "%2F").gsub(/^#+/) { |m| '.' * m.length }
     end
 
     def channel_unescape(channel)
-      "##{channel.gsub(/^\.+/) { |m| '#' * m.length }}"
+      "##{channel.gsub(/%2F+/, "/").gsub(/^\.+/) { |m| '#' * m.length }}"
     end
 
     def channel_url(channel, postfix=nil)

--- a/lib/irclogger/viewer_helpers.rb
+++ b/lib/irclogger/viewer_helpers.rb
@@ -4,56 +4,30 @@ module IrcLogger
   module ViewerHelpers
     include Rack::Utils
     
+    CHANNEL_ESCAPE = {
+      '~' => '~~',
+      '#' => '~h~',
+      '/' => '~s~',
+      '%' => '~p~',
+      '\\' => '~r~',
+      '?' => '~q~',
+      '`' => '~a~',
+      '<' => '~l~',
+      '>' => '~g~',
+      '|' => '~b~',
+      '{' => '~o~',
+      '}' => '~c~',
+      '^' => '~x~',
+      '"' => '~d~'
+    }
+    
     def escape_url(url)
-        url.gsub('~', '~~').
-            gsub('#', '~h~').
-            gsub('/', '~s~').
-            gsub('%', '~p~').
-            gsub('\\', '~r~').
-            gsub('?', '~q~').
-            gsub('`', '~a~').
-            gsub('<', '~l~').
-            gsub('>', '~g~').
-            gsub('|', '~b~').
-            gsub('{', '~o~').
-            gsub('}', '~c~').
-            gsub('^', '~x~').
-            gsub('"', '~d~')
+      url.gsub(/(.)/) { |m| CHANNEL_ESCAPE.key?(m) ? CHANNEL_ESCAPE[m] : m }
     end
     
     def unescape_url(url)
-        i = 0
-        text = ""
-        parts = url.split('~', -1)
-        while i < parts.length do
-            if i.even?
-                text += parts[i]
-            else
-                if parts[i].length == 0
-                    text += '~'
-                else
-                    if parts[i].length  == 1
-                        text += parts[i].gsub('h', '#').
-                                         gsub('s', '/').
-                                         gsub('p', '%').
-                                         gsub('r', '\\').
-                                         gsub('q', '?').
-                                         gsub('a', '`').
-                                         gsub('l', '<').
-                                         gsub('g', '>').
-                                         gsub('b', '|').
-                                         gsub('o', '{').
-                                         gsub('c', '}').
-                                         gsub('x', '^').
-                                         gsub('d', '"')
-                    else
-                        text += parts[i]
-                    end
-                end
-            end
-            i += 1
-        end
-        text
+      inv = CHANNEL_ESCAPE.invert 
+      url.gsub(/~[^~]?~/) { |m| inv.key?(m) ? inv[m] : m }
     end
         
 
@@ -63,11 +37,10 @@ module IrcLogger
 
     def channel_unescape(channel)
       c = unescape_url(channel)
-      if Config.key?('legacy') and Config['legacy'].include? c
+      if Config.key?('legacy') && Config['legacy'].include?(c) then
         "##{c.gsub(/^\.+/) { |m| '#' * m.length }}"
-      else
-        "##{c}"
       end
+      "##{c}"
     end
 
     def channel_url(channel, postfix=nil)

--- a/lib/irclogger/viewer_helpers.rb
+++ b/lib/irclogger/viewer_helpers.rb
@@ -20,14 +20,14 @@ module IrcLogger
       '^' => '~x~',
       '"' => '~d~'
     }
+    CHANNEL_ESCAPE_INVERTED = CHANNEL_ESCAPE.invert
     
     def escape_url(url)
       url.gsub(/(.)/) { |m| CHANNEL_ESCAPE.key?(m) ? CHANNEL_ESCAPE[m] : m }
     end
     
     def unescape_url(url)
-      inv = CHANNEL_ESCAPE.invert 
-      url.gsub(/~[^~]?~/) { |m| inv.key?(m) ? inv[m] : m }
+      url.gsub(/~[^~]?~/) { |m| CHANNEL_ESCAPE_INVERTED.key?(m) ? CHANNEL_ESCAPE_INVERTED[m] : m }
     end
         
 


### PR DESCRIPTION
Its me again

@eggrobin discovered that the log viewer breaks on channel names containing a forward slash, because they don't get escaped. This pull request handles (or at least tries to) this.

Additionally, we (or rather eggrobin) detected another bug. When a channel name starts with a . after the #, the logger won't be able to see a difference between #.channelname and ##channelname. Of course this could be changed, by simply leaving the second # there, and not changing it to a ., but this would break the links for this channel on your logging instance: https://irclog.whitequark.org/.openfpga/2017-03-05
As they might use the logs through the link, breaking it might be a bit unfortunate.

Do you have any ideas on this?