### PR TITLE
 Don't drop messages sent at exactly midnight

### DIFF
--- a/lib/irclogger/message.rb
+++ b/lib/irclogger/message.rb
@@ -46,7 +46,7 @@ class Message < Sequel::Model(:irclog)
   def self.find_by_channel_and_date(channel, date)
     day_after = date + 1
 
-    filter('timestamp > ? and timestamp < ?',
+    filter('timestamp >= ? and timestamp < ?',
                   Time.utc(date.year, date.month, date.day).to_i,
                   Time.utc(day_after.year, day_after.month, day_after.day).to_i).
       filter(:channel => channel).
@@ -63,7 +63,7 @@ class Message < Sequel::Model(:irclog)
     from = Time.utc(date.year, date.month, 1)
     to   = Time.utc((date >> 1).year, (date >> 1).month, 1) - 1
 
-    filter('timestamp > ? and timestamp < ?', from.to_i, to.to_i).
+    filter('timestamp >= ? and timestamp < ?', from.to_i, to.to_i).
         filter(:channel => channel).
         order(:timestamp, :id)
   end
@@ -72,7 +72,7 @@ class Message < Sequel::Model(:irclog)
     from = Time.utc(date.year, date.month, 1)
     to   = Time.utc((date >> 1).year, (date >> 1).month, 1) - 1
 
-    filter('timestamp > ? and timestamp < ?', from.to_i, to.to_i).
+    filter('timestamp >= ? and timestamp < ?', from.to_i, to.to_i).
         filter(:channel => channel).
         count > 0
   end
@@ -126,7 +126,7 @@ class Message < Sequel::Model(:irclog)
   def self.most_recent_topic_for(channel, date)
     order(:timestamp).
         filter(channel: channel, opcode: 'topic').
-        filter('timestamp < ?',
+        filter('timestamp <= ?',
                Time.utc(date.year, date.month, date.day).to_i).
         last
   end

--- a/lib/irclogger/message.rb
+++ b/lib/irclogger/message.rb
@@ -126,7 +126,8 @@ class Message < Sequel::Model(:irclog)
   def self.most_recent_topic_for(channel, date)
     order(:timestamp).
         filter(channel: channel, opcode: 'topic').
-        filter('timestamp < ?', date.to_time.to_i).
+        filter('timestamp < ?',
+               Time.utc(date.year, date.month, date.day).to_i).
         last
   end
 


### PR DESCRIPTION
Right now, messages sent at the stroke of midnight are not displayed. This fixes the logic to display them.

Also, the time used for finding the most recent topic is now calculated from UTC rather than from local time, and topic changes at midnight are included too.