### PR TITLE
logger: add ssl_verify config option

### DIFF
--- a/logger.rb
+++ b/logger.rb
@@ -26,6 +26,7 @@ bot = Cinch::Bot.new do
     c.server   = Config['server']
     c.port     = Config['port'] unless Config['port'].nil?
     c.ssl.use  = Config['ssl'] unless Config['ssl'].nil?
+    c.ssl.verify = Config['ssl_verify'] unless Config['ssl_verify'].nil?
 
     # Auth config
     c.user     = Config['username']


### PR DESCRIPTION
Hi! this adds an extra config option `ssl_verify` that maps to Cinch's `ssl.verify` - I'm pointing this at a ZNC server (on the same machine) which uses a self-signed certificate, so need to be able to disable verification to connect.

Not married to the option name, and perhaps it would be better to map `Config['ssl']` straight to Cinch's so all 3 sub-options are available, but that'd be a breaking change (without further shenanigans) and is probably not worth bikeshedding 😅