### PR TITLE
Permit absolute paths for ircviewer's Unix socket

### DIFF
--- a/bin/viewer.rb
+++ b/bin/viewer.rb
@@ -15,7 +15,7 @@ if Config['web'].include? ':'
   host, port = Config['web'].split(':')
   server_args = [host, port.to_i]
 else
-  server_args = [File.join(Config['files']['tmp'], Config['web'])]
+  server_args = [File.expand_path(Config['web'], Config['files']['tmp'])]
 end
 
 server = Thin::Server.new(*server_args) do


### PR DESCRIPTION
The previous behavior with relative paths is preserved.